### PR TITLE
Remove Nuclear Option from CC HQ, replace with cluster grenade

### DIFF
--- a/Resources/Maps/_SSS/centcomm-hq-sss.yml
+++ b/Resources/Maps/_SSS/centcomm-hq-sss.yml
@@ -49553,7 +49553,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 1
-- proto: NuclearGrenade
+- proto: ClusterGrenade
   entities:
   - uid: 11886
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaces the nuclear option with a cluster grenade because nuclear options are too destructive

**Changelog**
:cl: Simyon
- tweak: Removed Nuclear Option from CC HQ, replaced with cluster grenade.
