### PR TITLE
Hide Unnecessary Roles

### DIFF
--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -50,8 +50,13 @@ public sealed class JobTest
         var mindSys = pair.Server.System<MindSystem>();
         var roleSys = pair.Server.System<RoleSystem>();
         var ticker = pair.Server.System<GameTicker>();
+        var prototypeManager = pair.Server.ProtoMan;
 
         user ??= pair.Client.User!.Value;
+
+        // If it shouldn't exist in preferences, it shouldn't be tested.
+        if (prototypeManager.TryIndex(job, out var jobPrototype) && !jobPrototype.SetPreference)
+            return;
 
         Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
         Assert.That(ticker.PlayerGameStatuses[user.Value], Is.EqualTo(PlayerGameStatus.JoinedGame));

--- a/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
+++ b/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
@@ -203,50 +203,6 @@ public sealed class StationJobsTest
         });
         await pair.CleanReturnAsync();
     }
-
-    [Test]
-    public async Task InvalidRoundstartJobsTest()
-    {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
-
-        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
-        var compFact = server.ResolveDependency<IComponentFactory>();
-        var name = compFact.GetComponentName<StationJobsComponent>();
-
-        await server.WaitAssertion(() =>
-        {
-            // invalidJobs contains all the jobs which can't be set for preference:
-            // i.e. all the jobs that shouldn't be available round-start.
-            var invalidJobs = new HashSet<string>();
-            foreach (var job in prototypeManager.EnumeratePrototypes<JobPrototype>())
-            {
-                if (!job.SetPreference)
-                    invalidJobs.Add(job.ID);
-            }
-
-            Assert.Multiple(() =>
-            {
-                foreach (var gameMap in prototypeManager.EnumeratePrototypes<GameMapPrototype>())
-                {
-                    foreach (var (stationId, station) in gameMap.Stations)
-                    {
-                        if (!station.StationComponentOverrides.TryGetComponent(name, out var comp))
-                            continue;
-
-                        foreach (var (job, array) in ((StationJobsComponent) comp).SetupAvailableJobs)
-                        {
-                            Assert.That(array.Length, Is.EqualTo(2));
-                            Assert.That(array[0] is -1 or >= 0);
-                            Assert.That(array[1] is -1 or >= 0);
-                            Assert.That(invalidJobs, Does.Not.Contain(job), $"Station {stationId} contains job prototype {job} which cannot be present roundstart.");
-                        }
-                    }
-                }
-            });
-        });
-        await pair.CleanReturnAsync();
-    }
 }
 
 internal static class JobExtensions

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -46,7 +46,7 @@ public sealed partial class DepartmentPrototype : IPrototype
     /// Toggles the display of the department in the priority setting menu in the character editor.
     /// </summary>
     [DataField]
-    public bool EditorHidden;
+    public bool EditorHidden { get; private set; } = true;
 }
 
 /// <summary>

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -66,7 +66,7 @@ namespace Content.Shared.Roles
         ///     Should this job appear in preferences menu?
         /// </summary>
         [DataField("setPreference")]
-        public bool SetPreference { get; private set; } = true;
+        public bool SetPreference { get; private set; }
 
         /// <summary>
         ///     Should the selected traits be applied for this job?
@@ -125,9 +125,6 @@ namespace Content.Shared.Roles
         /// </summary>
         [DataField]
         public EntProtoId? JobPreviewEntity = null;
-
-        [DataField]
-        public bool RoleVisibleInPreferences { get; private set; }
 
         [DataField]
         public ProtoId<JobIconPrototype> Icon { get; private set; } = "JobIconUnknown";

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -127,6 +127,9 @@ namespace Content.Shared.Roles
         public EntProtoId? JobPreviewEntity = null;
 
         [DataField]
+        public bool RoleVisibleInPreferences { get; private set; }
+
+        [DataField]
         public ProtoId<JobIconPrototype> Icon { get; private set; } = "JobIconUnknown";
 
         [DataField("special", serverOnly: true)]

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -6,6 +6,7 @@
   startingGear: PassengerGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone
+  setPreference: true
   access:
   - Maintenance
 

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -12,6 +12,7 @@
   id: Civilian
   name: department-Civilian
   description: department-Civilian-description
+  editorHidden: false
   color: "#9FED58"
   weight: -10
   roles:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Hides the unused roles from the preference list. Should probably reset preferences too so people don't fuck themself over permanently.

## Media
![image](https://github.com/user-attachments/assets/89c36733-1b3a-42f2-bcd9-b868d23a6670)

## Changelog
:cl:
- tweak: Fixed other roles showing up in selection.
