### PR TITLE
One Shot Throwing Knife

### DIFF
--- a/Content.Server/Damage/Components/DamageOtherOnHitComponent.cs
+++ b/Content.Server/Damage/Components/DamageOtherOnHitComponent.cs
@@ -15,5 +15,19 @@ namespace Content.Server.Damage.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public DamageSpecifier Damage = default!;
 
+        [DataField("damageMultiplierOverTime")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float DamageMultiplierOverTime = 1f;
+
+        [DataField("timeTillMaxDamage")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float TimeTillMaxDamage = 0f;
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public TimeSpan TimeThrown = TimeSpan.Zero;
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public TimeSpan TimeToMaxDamage = TimeSpan.Zero;
+
     }
 }

--- a/Resources/Locale/en-US/_SSS/store_items.ftl
+++ b/Resources/Locale/en-US/_SSS/store_items.ftl
@@ -7,3 +7,6 @@ uplink-disruptive-throwable-desc = A set of 1 flash, smoke and stinger grenades.
 uplink-exploding-syndicate-bomb-SSS-desc = A big, anchored bomb that can create a huge explosion if not defused in time. Useful as a distraction. Has an adjustable timer with a minimum setting of 90 seconds. Stays quiet for 30 seconds upon activation.
 uplink-armour-upgrade-name = Armour Upgrade Kit
 uplink-armour-upgrade-desc = An armour upgrade kit. Use on your armour to upgrade the protection. Armour will drop if equipped!
+
+uplink-one-shot-knife-name = Throwing Knife
+uplink-one-shot-knife-desc = A combat knife that appears to be normal, but its damage scales with how long its been in the air, dealing up to 100 damage. Destroyed after use, so use it wisely!

--- a/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
+++ b/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
@@ -85,6 +85,17 @@
     Telecrystal: 4
 
 - type: listing
+  id: UplinkOneShotKnifeSSS
+  name: uplink-one-shot-knife-name
+  description: uplink-one-shot-knife-desc
+  icon: { sprite: /Textures/Objects/Weapons/Melee/combat_knife.rsi, state: icon }
+  productEntity: CombatKnifeOneShotThrowing
+  categories:
+  - SSSTraitorWeapons
+  cost:
+    Telecrystal: 2
+
+- type: listing
   id: UplinkExplosiveGrenadeSSS
   name: uplink-explosive-grenade-name
   description: uplink-explosive-grenade-desc

--- a/Resources/Prototypes/_SSS/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_SSS/Entities/Objects/Weapons/Melee/knife.yml
@@ -1,0 +1,17 @@
+- type: entity
+  name: combat knife
+  suffix: 1-Hit Throw
+  parent: CombatKnife
+  id: CombatKnifeOneShotThrowing
+  description: A deadly knife intended for melee confrontations.
+  components:
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 5
+    damageMultiplierOverTime: 20
+    timeTillMaxDamage: 0.475
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+    offset: -0.15,0.0
+    deleteOnRemove: true


### PR DESCRIPTION
## About the PR
Adds a knife that can one shot if thrown from far enough away, breaks after hitting something, and costs 2 tc. Traitor only.

## Media
I took a video but then lost it oops

**Changelog**
:cl:
- add: Added new traitor item, (Throwing) Combat Knife. Costs 2 tc, looks like a normal combat knife but can one shot if thrown from ~8 tiles away.
