### PR TITLE
Remove Bloodloss Damage

### DIFF
--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -140,23 +140,24 @@ public sealed class BloodstreamSystem : EntitySystem
             var bloodPercentage = GetBloodLevelPercentage(uid, bloodstream);
             if (bloodPercentage < bloodstream.BloodlossThreshold && !_mobStateSystem.IsDead(uid))
             {
-                // bloodloss damage is based on the base value, and modified by how low your blood level is.
-                var amt = bloodstream.BloodlossDamage / (0.1f + bloodPercentage);
-
-                _damageableSystem.TryChangeDamage(uid, amt,
-                    ignoreResistances: false, interruptsDoAfters: false);
-
-                // Apply dizziness as a symptom of bloodloss.
-                // The effect is applied in a way that it will never be cleared without being healthy.
-                // Multiplying by 2 is arbitrary but works for this case, it just prevents the time from running out
-                _drunkSystem.TryApplyDrunkenness(
-                    uid,
-                    (float) bloodstream.UpdateInterval.TotalSeconds * 2,
-                    applySlur: false);
-                _stutteringSystem.DoStutter(uid, bloodstream.UpdateInterval * 2, refresh: false);
-
-                // storing the drunk and stutter time so we can remove it independently from other effects additions
-                bloodstream.StatusTime += bloodstream.UpdateInterval * 2;
+                // SSS - Disable bloodloss damage and bloodloss effects
+                // // bloodloss damage is based on the base value, and modified by how low your blood level is.
+                // var amt = bloodstream.BloodlossDamage / (0.1f + bloodPercentage);
+                //
+                // _damageableSystem.TryChangeDamage(uid, amt,
+                //     ignoreResistances: false, interruptsDoAfters: false);
+                //
+                // // Apply dizziness as a symptom of bloodloss.
+                // // The effect is applied in a way that it will never be cleared without being healthy.
+                // // Multiplying by 2 is arbitrary but works for this case, it just prevents the time from running out
+                // _drunkSystem.TryApplyDrunkenness(
+                //     uid,
+                //     (float) bloodstream.UpdateInterval.TotalSeconds * 2,
+                //     applySlur: false);
+                // _stutteringSystem.DoStutter(uid, bloodstream.UpdateInterval * 2, refresh: false);
+                //
+                // // storing the drunk and stutter time so we can remove it independently from other effects additions
+                // bloodstream.StatusTime += bloodstream.UpdateInterval * 2;
             }
             else if (!_mobStateSystem.IsDead(uid))
             {
@@ -166,11 +167,13 @@ public sealed class BloodstreamSystem : EntitySystem
                     bloodstream.BloodlossHealDamage * bloodPercentage,
                     ignoreResistances: true, interruptsDoAfters: false);
 
-                // Remove the drunk effect when healthy. Should only remove the amount of drunk and stutter added by low blood level
-                _drunkSystem.TryRemoveDrunkenessTime(uid, bloodstream.StatusTime.TotalSeconds);
-                _stutteringSystem.DoRemoveStutterTime(uid, bloodstream.StatusTime.TotalSeconds);
-                // Reset the drunk and stutter time to zero
-                bloodstream.StatusTime = TimeSpan.Zero;
+                // SSS - Disable bloodloss damage and bloodloss effects
+                // (Bloodloss healing is kept because there are weapons that directly deal bloodloss damage)
+                // // Remove the drunk effect when healthy. Should only remove the amount of drunk and stutter added by low blood level
+                // _drunkSystem.TryRemoveDrunkenessTime(uid, bloodstream.StatusTime.TotalSeconds);
+                // _stutteringSystem.DoRemoveStutterTime(uid, bloodstream.StatusTime.TotalSeconds);
+                // // Reset the drunk and stutter time to zero
+                // bloodstream.StatusTime = TimeSpan.Zero;
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes blood loss damage, and the associated effects like stuttering and dizziness.

Bleeding will still occur with a purpose of leaving blood puddles as a visual indicator that someone got hurt in that area.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
DoT damage from blood loss doesn't fit in SSS, because there are barely any blood packs and dying from bleed damage instead of that last bullet that hit you isn't very engaging gameplay. No more DoT damage also means that weapons will be easier to balance.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Bleeding without blood loss damage
![2025-01-02-123513_hyprshot](https://github.com/user-attachments/assets/507f4036-7c64-4e55-a242-70c3e25ca59d)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Skubman
- remove: Removed blood loss damage, dizziness and stuttering due to bleeding. Bleeding is now just a visual indicator.